### PR TITLE
fix: Explicitly enable release note generation in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,5 +59,6 @@ jobs:
           body_path: ""
           draft: true
           prerelease: false
+          generate_release_notes: true # Explicitly set to true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Added `generate_release_notes: true` to the `softprops/action-gh-release@v2` step in the `.github/workflows/release.yml` file.

This is to ensure that the action attempts to automatically generate release notes based on commits since the last tag.